### PR TITLE
Add CVar to change the MP5 fire-rate (sv_ag_mp5_old_rate)

### DIFF
--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -41,6 +41,7 @@ cvar_t	teamlist = {"mp_teamlist","hgrunt;scientist", FCVAR_SERVER };
 cvar_t	teamoverride = {"mp_teamoverride","1" };
 cvar_t	defaultteam = {"mp_defaultteam","0" };
 cvar_t	allowmonsters={"mp_allowmonsters","0", FCVAR_SERVER };
+cvar_t  mp5_old_rate = { "sv_ag_mp5_old_rate", "0", FCVAR_SERVER };
 
 cvar_t  allow_spectators = { "allow_spectators", "1.0", FCVAR_SERVER };		// 0 prevents players from being spectators
 
@@ -500,6 +501,8 @@ void GameDLLInit( void )
 	CVAR_REGISTER (&teamoverride);
 	CVAR_REGISTER (&defaultteam);
 	CVAR_REGISTER (&allowmonsters);
+
+	CVAR_REGISTER (&mp5_old_rate);
 
 	CVAR_REGISTER (&mp_chattime);
 	CVAR_REGISTER (&mp_intermission_time);

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -37,6 +37,7 @@ extern cvar_t	teamoverride;
 extern cvar_t	defaultteam;
 extern cvar_t	allowmonsters;
 extern cvar_t	mp_chattime;
+extern cvar_t   mp5_old_rate;
 
 extern cvar_t	singleplayer;
 extern cvar_t	sploading;

--- a/dlls/mp5.cpp
+++ b/dlls/mp5.cpp
@@ -28,6 +28,9 @@
 #endif
 //-- Martin Webrant
 
+// Sabian Roberts
+#include "game.h"
+
 enum mp5_e
 {
 	MP5_LONGIDLE = 0,
@@ -148,6 +151,9 @@ BOOL CMP5::Deploy( )
 
 void CMP5::PrimaryAttack()
 {
+#ifndef CLIENT_DLL
+	int mp5OldRate = mp5_old_rate.value;
+#endif
 	// don't fire underwater
 	if (m_pPlayer->pev->waterlevel == 3)
 	{
@@ -198,7 +204,10 @@ void CMP5::PrimaryAttack()
 	m_flNextPrimaryAttack = GetNextAttackDelay(0.1);
 
 	if ( m_flNextPrimaryAttack < UTIL_WeaponTimeBase() )
-		m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.1;
+#ifndef CLIENT_DLL
+		if (mp5_old_rate.value == 0) m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.1;
+		if (mp5_old_rate.value == 1) m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.09;
+#endif
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + UTIL_SharedRandomFloat( m_pPlayer->random_seed, 10, 15 );
 }


### PR DESCRIPTION
In the WON versions of Half-Life, as proven by [this video at timestamp 2:20,](https://www.youtube.com/watch?v=uKkJPFmDW9Q) the fire-rate for the MP5 was slightly faster than it is in the current Steam version of HL, including AG. I thought it would be nice to add this CVar for version 6.7, as players may want the old fire-rate.