### PR TITLE
Stop forcing engine to use server.cfg, even when server is a listen server

### DIFF
--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -323,16 +323,8 @@ AgGameRules* InstallGameRules(void)
 	SERVER_COMMAND( "exec game.cfg\n" );
 	SERVER_EXECUTE( );
 
-	//++ BulliT
-	char* servercfgfile = (char*)CVAR_GET_STRING("servercfgfile");
-	if (servercfgfile && servercfgfile[0])
-	{
-		char szCommand[256];
 
-		ALERT(at_console, "Executing dedicated server config file\n");
-		sprintf(szCommand, "exec %s\n", servercfgfile);
-		SERVER_COMMAND(szCommand);
-	}
+
 
 #ifndef AG_NO_CLIENT_DLL
 	//Detect CTF maps.

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -105,10 +105,18 @@ CHalfLifeMultiplay :: CHalfLifeMultiplay()
 	// Added lservercfg file cvar, since listen and dedicated servers should not
 	// share a single config file. (sjb)
 //++ BulliT
-/*
+
 	if ( IS_DEDICATED_SERVER() )
 	{
-		// this code has been moved into engine, to only run server.cfg once
+		//++ BulliT
+		char* servercfgfile = (char*)CVAR_GET_STRING("servercfgfile");
+		if (servercfgfile && servercfgfile[0])
+		{
+			char szCommand[256];
+
+			ALERT(at_console, "Executing dedicated server config file\n");
+			sprintf(szCommand, "exec %s\n", servercfgfile);
+			SERVER_COMMAND(szCommand);
 	}
 	else
 	{
@@ -124,7 +132,6 @@ CHalfLifeMultiplay :: CHalfLifeMultiplay()
 			SERVER_COMMAND( szCommand );
 		}
 	}
-  */
   //-- Martin Webrant
 }
 


### PR DESCRIPTION
BulliT's original AG code stopped the engine from using listenserver.cfg and instead only use server.cfg, which can present problems if there're listings in settings.scr. I have tested it on listenservers, but I have yet to test it on a dedicated server, but it should work if the `IS_DEDICATED_SERVER` works.