### PR TITLE
Fixed mangled game description resulting in servers not appearing in "Find servers"

### DIFF
--- a/dlls/aggamemode.cpp
+++ b/dlls/aggamemode.cpp
@@ -54,6 +54,14 @@ AgString AgGamename()
     return "Half-Life";
 }
 
+const char *AgGamenameChar()
+{
+	if (g_pGame)
+		return g_pGame->m_sName.c_str();
+	else
+		return "Half-Life";
+}
+
 AgString AgGamedescription()
 {
     if (g_pGame)

--- a/dlls/aggamemode.h
+++ b/dlls/aggamemode.h
@@ -42,6 +42,7 @@ public:
 };
 
 extern DLL_GLOBAL AgGameMode GameMode;
+const char* AgGamenameChar();
 AgString AgGamename();
 AgString AgGamedescription();
 

--- a/dlls/aggamerules.h
+++ b/dlls/aggamerules.h
@@ -69,7 +69,7 @@ public:
 
     virtual void RefreshSkillData(void);
 
-    virtual const char* GetGameDescription(void) { return AgGamename().c_str(); }  // this is the game name that gets seen in the server browser  
+    virtual const char* GetGameDescription(void) { return AgGamenameChar(); }  // this is the game name that gets seen in the server browser
     //New
     bool    AgThink();
     void    Start(const AgString& sSpawn);


### PR DESCRIPTION
Hello.

This fixes a problem where sometimes(?) if the Game description was not changed externally (e.g. AMXX plugin) the servers using the AG 6.7 ag.so did not appear in the **Find servers** list, because of the GetGameDescription() (and therefore AgGamename()) returning garbage memory space instead of the actual gamemode name.

Getting a server info from master list with AG 6.7 before this change:
```SourceInfo(protocol=48, server_name='Play AG PLAY IT NOW.', map_name='crossfire', folder='ag', game='�������\x08����', app_id=70, player_count=0, max_players=24, bot_count=0, server_type='d', platform='l', password_protected=False, vac_enabled=False, version='1.1.2.2/Stdio', edf=177, port=27016, steam_id=90148575774881794, stv_port=None, stv_name=None, keywords='', game_id=70, ping=0.00662029700470157)```

After:
```SourceInfo(protocol=48, server_name='Play AG PLAY IT NOW.', map_name='crossfire', folder='ag', game='AG TDM', app_id=70, player_count=0, max_players=24, bot_count=0, server_type='d', platform='l', password_protected=False, vac_enabled=False, version='1.1.2.2/Stdio', edf=177, port=27016, steam_id=90148575585675274, stv_port=None, stv_name=None, keywords='', game_id=70, ping=0.009339504002127796)```

![image](https://user-images.githubusercontent.com/5108747/124014184-7e051d00-d9e3-11eb-9448-f296145c0b8e.png)


You can also see this problem on exec's SourceRuns - AG 6.7 server, that doesn't appear in the server listing:
```SourceInfo(protocol=48, server_name='SourceRuns - AG 6.7', map_name='crossfire', folder='ag', game='�\x0bM\n�����\x1aW\nv�6A�\x15��\x10�Q\n`JV\t.BA�\x10�Q\n����', app_id=70, player_count=1, max_players=16, bot_count=0, server_type='d', platform='l', password_protected=False, vac_enabled=True, version='1.1.2.2/Stdio', edf=145, port=27015, steam_id=90147897128590336, stv_port=None, stv_name=None, keywords=None, game_id=70, ping=0.04774829399684677)```

I assume it's because of this https://stackoverflow.com/a/27627466 and I guess some change(?) between C++/compiler versions, since it worked in AG 6.6 before? Dunno, my knowledge of C++ is limited.

PR tested on gcc 11 w/ C++11 and C++14, works fine on both.