### PR TITLE
Fix cvar query/query response spam & invalid command spam

### DIFF
--- a/dlls/aggamemode.cpp
+++ b/dlls/aggamemode.cpp
@@ -213,10 +213,10 @@ void AgGameMode::Think()
             classifiedFpsMaxValues[closestValue]++;
         }
 
-        if (ag_fps_limit_auto_check_interval.value < MIN_FPS_LIMIT_CHECK_INTERVAL)
-            CVAR_SET_FLOAT("ag_fps_limit_auto_check_interval", MIN_FPS_LIMIT_CHECK_INTERVAL);
+        if (ag_fps_limit_check_interval.value < MIN_FPS_LIMIT_CHECK_INTERVAL)
+            CVAR_SET_FLOAT("ag_fps_limit_check_interval", MIN_FPS_LIMIT_CHECK_INTERVAL);
 
-        m_fNextFpsLimitCheck = gpGlobals->time + ag_fps_limit_auto_check_interval.value;
+        m_fNextFpsLimitCheck = gpGlobals->time + ag_fps_limit_check_interval.value;
 
         if (players == 0)
             return;

--- a/dlls/agglobal.cpp
+++ b/dlls/agglobal.cpp
@@ -201,7 +201,7 @@ DLL_GLOBAL cvar_t	ag_spawn_pa_safe_chance    = { "ag_spawn_pa_safe_chance",    "
 // of having to do this with both sv_ag_fps_limit and ag_fps_limit. We'll see if it's the right decision
 DLL_GLOBAL cvar_t	ag_fps_limit = { "ag_fps_limit", "0", FCVAR_SERVER };  // Default: 0 - Cap players' fps_max. Standard in 2021 is 144 (125 and 100 before; 250 for bhop)
 DLL_GLOBAL cvar_t	ag_fps_limit_auto = { "ag_fps_limit_auto", "0", FCVAR_SERVER };  // Default: 0 - Whether to limit the fps to the most common fps among players
-DLL_GLOBAL cvar_t	ag_fps_limit_auto_check_interval = { "ag_fps_limit_auto_check_interval", "10.0", FCVAR_SERVER };  // Default: 10 seconds - How often to check for changing the limit
+DLL_GLOBAL cvar_t	ag_fps_limit_check_interval = { "ag_fps_limit_check_interval", "10.0", FCVAR_SERVER };  // Default: 10 seconds - How often to check for changing the limit
 DLL_GLOBAL cvar_t	ag_fps_limit_match_only = { "ag_fps_limit_match_only", "0", FCVAR_SERVER };  // Default: 0 - Whether to limit it only for players in a match
 DLL_GLOBAL cvar_t	ag_fps_limit_steampipe = { "ag_fps_limit_steampipe", "1", FCVAR_SERVER };  // Default: 1 - Whether to account for the 0.5 fps added by the engine (steampipe)
 DLL_GLOBAL cvar_t	ag_fps_limit_warnings = { "ag_fps_limit_warnings", "3", FCVAR_SERVER };  // Default: 3 - How many warnings before applying the punishment
@@ -222,7 +222,7 @@ extern AgString g_sGamemode;
 std::vector<std::string> g_votableSettings = {
     "ag_fps_limit",
     "ag_fps_limit_auto",
-    "ag_fps_limit_auto_check_interval",
+    "ag_fps_limit_check_interval",
     "ag_gauss_fix",
     "ag_rpg_fix",
     "ag_spawn_avoid_last_spots",
@@ -397,7 +397,7 @@ void AgInitGame()
 
     CVAR_REGISTER(&ag_fps_limit);
     CVAR_REGISTER(&ag_fps_limit_auto);
-    CVAR_REGISTER(&ag_fps_limit_auto_check_interval);
+    CVAR_REGISTER(&ag_fps_limit_check_interval);
     CVAR_REGISTER(&ag_fps_limit_match_only);
     CVAR_REGISTER(&ag_fps_limit_steampipe);
     CVAR_REGISTER(&ag_fps_limit_warnings);

--- a/dlls/agglobal.h
+++ b/dlls/agglobal.h
@@ -177,7 +177,7 @@ extern cvar_t ag_spawn_pa_safe_chance;
 
 extern cvar_t ag_fps_limit;
 extern cvar_t ag_fps_limit_auto;
-extern cvar_t ag_fps_limit_auto_check_interval;
+extern cvar_t ag_fps_limit_check_interval;
 extern cvar_t ag_fps_limit_match_only;
 extern cvar_t ag_fps_limit_steampipe;
 extern cvar_t ag_fps_limit_warnings;

--- a/dlls/agvote.cpp
+++ b/dlls/agvote.cpp
@@ -45,7 +45,7 @@ FILE_GLOBAL char* s_szVotes[] =
   "ag_spawn_pa_safe_chance <number> - Probability of a safe spawnpoint being chosen in the PA system",
   "ag_fps_limit <number> - 0 to disable, any other number to cap everyones' fps to that number",
   "ag_fps_limit_auto <number> - 0 to disable, 1 to limit automatically based on most used fps at that moment",
-  "ag_fps_limit_auto_check_interval <number> - How often to recalculate the fps limit when it's auto (in seconds)",
+  "ag_fps_limit_check_interval <number> - How often to recalculate the fps limit when it's auto (in seconds)",
 };
 
 AgVote::AgVote()

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1974,10 +1974,10 @@ void CBasePlayer::PreThink(void)
 	if ( g_fGameOver )
 		return;         // intermission or finale
 
-	if (!(pev->flags & FL_FAKECLIENT))
+	if ( m_fFpsMaxNextQuery =< gpGlobals->time && !(pev->flags & FL_FAKECLIENT) )
 	{
-		// It will crash if we query upon a bot
 		g_engfuncs.pfnQueryClientCvarValue2(edict(), "fps_max", request_ids::REQUEST_ID_FPS_MAX);
+		m_fFpsMaxNextQuery = gpGlobals->time + ag_fps_limit_auto_check_interval.value;
 	}
 
   //++ BulliT
@@ -6065,11 +6065,11 @@ void CBasePlayer::LimitFps()
 
 	if (fpsLimit >= m_flFpsMax)
 		return;
-	
-	CLIENT_COMMAND(edict(), "fps_max %.6f\n", fpsLimit);
 
 	if (m_flNextFpsWarning < gpGlobals->time)
 	{
+		CLIENT_COMMAND(edict(), "fps_max %.6f\n", fpsLimit);
+
 		m_flNextFpsWarning = gpGlobals->time + ag_fps_limit_warnings_interval.value;
 		m_iFpsWarnings++;
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1974,10 +1974,10 @@ void CBasePlayer::PreThink(void)
 	if ( g_fGameOver )
 		return;         // intermission or finale
 
-	if ( m_fFpsMaxNextQuery =< gpGlobals->time && !(pev->flags & FL_FAKECLIENT) )
+	if ( m_fFpsMaxNextQuery <= gpGlobals->time && !(pev->flags & FL_FAKECLIENT) )
 	{
 		g_engfuncs.pfnQueryClientCvarValue2(edict(), "fps_max", request_ids::REQUEST_ID_FPS_MAX);
-		m_fFpsMaxNextQuery = gpGlobals->time + ag_fps_limit_auto_check_interval.value;
+		m_fFpsMaxNextQuery = gpGlobals->time + ag_fps_limit_check_interval.value;
 	}
 
   //++ BulliT
@@ -2881,7 +2881,7 @@ void CBasePlayer::PostThink()
 		// When the fps limiter is set to auto, it handles the limitation in another place at a different interval (not every frame),
 		// so to simplify this and leave some room for the limit to change, we call `LimitFps()` in 2 different places depending on auto...
 		// TODO: when set to auto, the warning interval should probably still work as expected, but it won't
-		// for now since instead it will be every `ag_fps_limit_auto_check_interval` seconds most of the time
+		// for now since instead it will be every `ag_fps_limit_check_interval` seconds most of the time
 		LimitFps();
 	}
   

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -363,6 +363,8 @@ protected:
 
 	float m_fDisplayGamemode; //Next time to display gamemode.
 
+	float m_fFpsMaxNextQuery; //Next time to query client's fps_max
+
 	float m_fLongjumpTimer;   //Long jump timer.
 
 	Vector m_vKilled;         //Where the player got killed last time.
@@ -525,6 +527,8 @@ inline void CBasePlayer::Init()
 	m_iStatus = Invalid;
 
 	m_fDisplayGamemode = gpGlobals->time + 5;
+
+	m_fFpsMaxNextQuery = gpGlobals->time; // Check immediately if it's a new player
 
 	m_vKilled = g_vecZero;
 


### PR DESCRIPTION
Hello.

**The first part of this PR:** Adds the `m_fFpsMaxNextQuery` variable in order to only query fps_max on the `ag_fps_limit_auto_check_interval` interval even in `CBasePlayer::PreThink`, because querying a cvar every frame is expensive and **adds an overhead of around ~4k/s** (value taken net_graph "in" value) for the clients (and probably the server as well, just dunno how to check), and it also spams the HLDS console on every update when -dev is used.

**The second part of this PR** is moving the attempt to change fps_max into the nextFpsWarning interval, because of the fact the client can have `cl_filterstuffcmd` set to 1 on Steam HL engine clients and therefore his console is spammed with this message every frame:
```
"
Server tried to send invalid command:"fps_max 199.500000
```
^ This second part can probably be moved somewhere else (maybe in the PreThink interval I've added?) I dunno, really.

EDIT: Also the reason for not just querying for `cl_filterstuffcmd`'s value and only trying to set fps_max if it's set to 0 or it doesn't exist - is that the CVar is protected against read (yeah, even read lol)/write from the server. This was introduced to avoid slowhacking.


