### PR TITLE
Added env_model from Day of Defeat & Spirit SDK mods

### DIFF
--- a/dlls/effects.cpp
+++ b/dlls/effects.cpp
@@ -1343,6 +1343,186 @@ void CSprite::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useTy
 	}
 }
 
+//=================================================================
+// env_model: like env_sprite, except you can specify a sequence.
+//=================================================================
+#define SF_ENVMODEL_OFF			1
+#define SF_ENVMODEL_DROPTOFLOOR	2
+#define SF_ENVMODEL_SOLID		4
+
+class CEnvModel : public CBaseAnimating
+{
+	void Spawn( void );
+	void Precache( void );
+	void EXPORT Think( void );
+	void KeyValue( KeyValueData *pkvd );
+	void Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
+	virtual int	ObjectCaps( void ) { return CBaseEntity :: ObjectCaps() & ~FCAP_ACROSS_TRANSITION; }
+
+	virtual int		Save( CSave &save );
+	virtual int		Restore( CRestore &restore );
+	static	TYPEDESCRIPTION m_SaveData[];
+
+	void SetSequence( void );
+
+	string_t m_iszSequence_On;
+	string_t m_iszSequence_Off;
+	int m_iAction_On;
+	int m_iAction_Off;
+};
+
+TYPEDESCRIPTION CEnvModel::m_SaveData[] =
+{
+	DEFINE_FIELD( CEnvModel, m_iszSequence_On, FIELD_STRING ),
+	DEFINE_FIELD( CEnvModel, m_iszSequence_Off, FIELD_STRING ),
+	DEFINE_FIELD( CEnvModel, m_iAction_On, FIELD_INTEGER ),
+	DEFINE_FIELD( CEnvModel, m_iAction_Off, FIELD_INTEGER ),
+};
+
+IMPLEMENT_SAVERESTORE( CEnvModel, CBaseAnimating );
+LINK_ENTITY_TO_CLASS( env_model, CEnvModel );
+
+void CEnvModel::KeyValue( KeyValueData *pkvd )
+{
+	if (FStrEq(pkvd->szKeyName, "m_iszSequence_On"))
+	{
+		m_iszSequence_On = ALLOC_STRING(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "m_iszSequence_Off"))
+	{
+		m_iszSequence_Off = ALLOC_STRING(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "m_iAction_On"))
+	{
+		m_iAction_On = atoi(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "m_iAction_Off"))
+	{
+		m_iAction_Off = atoi(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else
+	{
+		CBaseAnimating::KeyValue( pkvd );
+	}
+}
+
+void CEnvModel :: Spawn( void )
+{
+	Precache();
+	SET_MODEL( ENT(pev), STRING(pev->model) );
+	UTIL_SetOrigin(pev, pev->origin);
+
+	if (pev->spawnflags & SF_ENVMODEL_SOLID)
+	{
+		pev->solid = SOLID_SLIDEBOX;
+		UTIL_SetSize(pev, Vector(-10, -10, -10), Vector(10, 10, 10));	//LRCT
+	}
+
+	if (pev->spawnflags & SF_ENVMODEL_DROPTOFLOOR)
+	{
+		pev->origin.z += 1;
+		DROP_TO_FLOOR ( ENT(pev) );
+	}
+	SetBoneController( 0, 0 );
+	SetBoneController( 1, 0 );
+
+	SetSequence();
+
+	pev->nextthink = gpGlobals->time + 0.1;
+}
+
+void CEnvModel::Precache( void )
+{
+	PRECACHE_MODEL( (char *)STRING(pev->model) );
+}
+
+void CEnvModel::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value )
+{
+	if (ShouldToggle(useType, !(pev->spawnflags & SF_ENVMODEL_OFF)))
+	{
+		if (pev->spawnflags & SF_ENVMODEL_OFF)
+			pev->spawnflags &= ~SF_ENVMODEL_OFF;
+		else
+			pev->spawnflags |= SF_ENVMODEL_OFF;
+
+		SetSequence();
+		pev->nextthink = gpGlobals->time + 0.1;
+	}
+}
+
+void CEnvModel::Think( void )
+{
+	int iTemp;
+
+	StudioFrameAdvance ( ); // set m_fSequenceFinished if necessary
+
+	if (m_fSequenceFinished && !m_fSequenceLoops)
+	{
+		if (pev->spawnflags & SF_ENVMODEL_OFF)
+			iTemp = m_iAction_Off;
+		else
+			iTemp = m_iAction_On;
+
+		switch (iTemp)
+		{
+		case 2: // change state
+			if (pev->spawnflags & SF_ENVMODEL_OFF)
+				pev->spawnflags &= ~SF_ENVMODEL_OFF;
+			else
+				pev->spawnflags |= SF_ENVMODEL_OFF;
+			SetSequence();
+			break;
+		default: //remain frozen
+			return;
+		}
+	}
+	pev->nextthink = gpGlobals->time + 0.1;
+}
+
+void CEnvModel :: SetSequence( void )
+{
+	int iszSeq;
+
+	if (pev->spawnflags & SF_ENVMODEL_OFF)
+		iszSeq = m_iszSequence_Off;
+	else
+		iszSeq = m_iszSequence_On;
+
+	if (!iszSeq)
+		return;
+	pev->sequence = LookupSequence( STRING( iszSeq ));
+
+	if (pev->sequence == -1)
+	{
+		if (pev->targetname)
+			ALERT( at_error, "env_model %s: unknown sequence \"%s\"\n", STRING( pev->targetname ), STRING( iszSeq ));
+		else
+			ALERT( at_error, "env_model: unknown sequence \"%s\"\n", STRING( pev->targetname ), STRING( iszSeq ));
+		pev->sequence = 0;
+	}
+
+	pev->frame = 0;
+	ResetSequenceInfo( );
+
+	if (pev->spawnflags & SF_ENVMODEL_OFF)
+	{
+		if (m_iAction_Off == 1)
+			m_fSequenceLoops = 1;
+		else
+			m_fSequenceLoops = 0;
+	}
+	else
+	{
+		if (m_iAction_On == 1)
+			m_fSequenceLoops = 1;
+		else
+			m_fSequenceLoops = 0;
+	}
+}
 
 class CGibShooter : public CBaseDelay
 {


### PR DESCRIPTION
Splitted changes to several pull requests for easier comparisions.

# Info

Alternative to `cycler_sprite` for placing decorative models, `env_model` was exist in **Day of Defeat** and Spirit-based mods (like **TWHL Tower 2**), so it also makes easier to port maps from that games.

**FGD class:**

```
@PointClass base(Targetname, Angles, MoveWith, RenderFields) studio() = env_model : "New alternative to cyclers" 
[
	model(studio) : "Model name"
	skin(integer) : "Skin" : 0
	body(integer) : "Body" : 0
	scale(string) : "Scale (1.0 = normal size)"

	m_iszSequence_On(string) : "Sequence when on"
	m_iAction_On(choices) : "Behaviour when on" : 0 =
	[
		0: "Freeze when sequence ends"
		1: "Loop"
		2: "Change state when sequence ends"
	]

	m_iszSequence_Off(string) : "Sequence when off"
	m_iAction_Off(choices) : "Behaviour when off" : 0 =
	[
		0: "Freeze when sequence ends"
		1: "Loop"
		2: "Change state when sequence ends"
	]

	spawnflags(flags) =
	[
		1: "Initially Off" : 0
		2: "Drop to Floor" : 0
		4: "Solid" : 0
	]
]
```